### PR TITLE
Fix Wi-Fi LED support and expose control to allow lambda calls

### DIFF
--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -144,16 +144,8 @@ void ToshibaClimateUart::setup() {
   this->start_handshake();
   // load initial sensor data from the unit
   this->getInitData();
-
-  if (this->wifi_led_disabled_) {
-    // Disable Wifi LED
-    this->sendCmd(ToshibaCommandType::WIFI_LED_1, 0x00);
-    this->sendCmd(ToshibaCommandType::WIFI_LED_2, 0x00);
-  } else {
-    // Enable Wifi LED
-    this->sendCmd(ToshibaCommandType::WIFI_LED_1, 0x05);
-    this->sendCmd(ToshibaCommandType::WIFI_LED_2, 0x05);
-  }
+  // Set Wi-Fi LED initial state
+  this->set_wifi_led(!this->wifi_led_disabled_);
 }
 
 /**
@@ -609,6 +601,21 @@ void ToshibaClimateUart::scan() {
   ESP_LOGI(TAG, "Scan started.");
   for (uint8_t i = 128; i < 255; i++) {
     this->requestData(static_cast<ToshibaCommandType>(i));
+  }
+}
+
+/**
+ * Expose Wi-Fi LED control
+ */
+void ToshibaClimateUart::set_wifi_led(bool enabled) {
+  if (enabled) {
+    ESP_LOGI(TAG, "Turning ON Wi-Fi LED");
+    this->sendCmd(ToshibaCommandType::WIFI_LED_1, 0x05);
+    this->sendCmd(ToshibaCommandType::WIFI_LED_2, 0x00);
+  } else {
+    ESP_LOGI(TAG, "Turning OFF Wi-Fi LED");
+    this->sendCmd(ToshibaCommandType::WIFI_LED_1, 0x00);
+    this->sendCmd(ToshibaCommandType::WIFI_LED_2, 0x80);
   }
 }
 

--- a/components/toshiba_suzumi/toshiba_climate.cpp
+++ b/components/toshiba_suzumi/toshiba_climate.cpp
@@ -147,7 +147,12 @@ void ToshibaClimateUart::setup() {
 
   if (this->wifi_led_disabled_) {
     // Disable Wifi LED
-    this->sendCmd(ToshibaCommandType::WIFI_LED, 128);
+    this->sendCmd(ToshibaCommandType::WIFI_LED_1, 0x00);
+    this->sendCmd(ToshibaCommandType::WIFI_LED_2, 0x00);
+  } else {
+    // Enable Wifi LED
+    this->sendCmd(ToshibaCommandType::WIFI_LED_1, 0x05);
+    this->sendCmd(ToshibaCommandType::WIFI_LED_2, 0x05);
   }
 }
 
@@ -177,7 +182,7 @@ void ToshibaClimateUart::process_command_queue_() {
     if (newCommand.cmd == ToshibaCommandType::DELAY) {
       this->command_queue_.erase(this->command_queue_.begin());
       return;
-    }    
+    }
     this->send_to_uart(this->command_queue_.front());
     this->command_queue_.erase(this->command_queue_.begin());
   }

--- a/components/toshiba_suzumi/toshiba_climate.h
+++ b/components/toshiba_suzumi/toshiba_climate.h
@@ -44,6 +44,7 @@ class ToshibaClimateUart : public PollingComponent, public climate::Climate, pub
   void dump_config() override;
   void update() override;
   void scan();
+  void set_wifi_led(bool enabled);
   float get_setup_priority() const override { return setup_priority::LATE; }
 
   void set_outdoor_temp_sensor(sensor::Sensor *outdoor_temp_sensor) { outdoor_temp_sensor_ = outdoor_temp_sensor; }

--- a/components/toshiba_suzumi/toshiba_climate_mode.h
+++ b/components/toshiba_suzumi/toshiba_climate_mode.h
@@ -69,7 +69,8 @@ enum class ToshibaCommandType : uint8_t {
   TARGET_TEMP = 179,
   ROOM_TEMP = 187,
   OUTDOOR_TEMP = 190,
-  WIFI_LED = 223,
+  WIFI_LED_1 = 222,
+  WIFI_LED_2 = 223,
   SPECIAL_MODE = 247,
 };
 


### PR DESCRIPTION
## Fix Wi-Fi LED support by adding 222 with correct ON/OFF command

* https://github.com/ormsport/ToshibaCarrierHvac/blob/7e3ab2bd0461e8073d3b55883ffc3a5209ec3a34/src/ToshibaCarrierHvac.h#L152-L153
* https://github.com/maxmacstn/ToshibaCarrierController/blob/ba1be8775a93487ab0d4aa2af9ee6c4f4ac31545/src/ToshibaCarrierCommands.h#L23-L24


## Expose Wi-Fi LED control to allow access from ESPHome lambda

ESPHome example

```yaml
switch:
  - platform: template
    name: WiFi LED
    id: wifi_led
    optimistic: true
    turn_on_action:
      - lambda: |-
          ESP_LOGD("main", "Turning ON Wi-Fi LED");
          auto* controller = static_cast<toshiba_suzumi::ToshibaClimateUart*>(id(${ac_id}));
          controller->set_wifi_led(true);
    turn_off_action:
      - lambda: |-
          ESP_LOGD("main", "Turning OFF Wi-Fi LED");
          auto* controller = static_cast<toshiba_suzumi::ToshibaClimateUart*>(id(${ac_id}));
          controller->set_wifi_led(false);
    entity_category: config
```